### PR TITLE
Use boid position when calculating average position

### DIFF
--- a/Assets/Scripts/Boid/BoidManager.cs
+++ b/Assets/Scripts/Boid/BoidManager.cs
@@ -134,7 +134,7 @@ public class BoidManager : MonoBehaviour
                         viewCount++;
 
                         // Add to average position for cohesion
-                        avgPosCohesion += boids[i].vel;
+                        avgPosCohesion += boids[i].pos;
 
                     }
                 } else {


### PR DESCRIPTION
For some reason the boid velocity was being used instead of the
position.