### PR TITLE
Make health bar the child of each unit

### DIFF
--- a/Assets/Scripts/Boid/Boid.cs
+++ b/Assets/Scripts/Boid/Boid.cs
@@ -114,8 +114,7 @@ public abstract class Boid : Selectable
             this._map = (Map.Map)map.GetComponent(typeof(Map.Map));
         }
         _localScale = transform.GetChild(0).transform.localScale;
-        _healthBar = Instantiate(healthBarPrefab, transform.position, Quaternion.identity);
-        _healthBar.GetComponent<HealthBar>().SetOwner(this);
+        _healthBar = Instantiate(healthBarPrefab, transform);
     }
 
     public void FixedUpdate()

--- a/Assets/Scripts/GameUI/HealthBar.cs
+++ b/Assets/Scripts/GameUI/HealthBar.cs
@@ -15,13 +15,14 @@ public class HealthBar : MonoBehaviour
     {
         _images = GetComponentsInChildren<Image>();
         _renderer = GetComponent<Renderer>();
+        transform.localPosition = new Vector3(0, 1, 0);
+        _boid = GetComponentInParent<Boid>();
     }
 
     // Update is called once per frame
     void Update()
     {
         fill.fillAmount = _boid.GetHealth() / _boid.GetMaxHealth();
-        transform.position = _boid.GetPos() + new Vector3(0, 1, 0);
         transform.forward = Camera.main.transform.forward;
         if (_boid.IsDead()) {
             Destroy(gameObject);
@@ -36,10 +37,5 @@ public class HealthBar : MonoBehaviour
             }
             img.color = col;
         }
-    }
-
-    public void SetOwner(Boid b)
-    {
-        this._boid = b;
     }
 }


### PR DESCRIPTION
This fixes the health bar not being destroyed when the unit is
destroyed, as well as making the relationship between unit and bar
objects clearer.