### PR TITLE
Implement pausing when opening the pause menu

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -134,6 +134,7 @@ public class GameManager : MonoBehaviour
 
     public void SetPaused(bool paused)
     {
+        Time.timeScale = paused ? 0 : 1;
         _paused = paused;
     }
 


### PR DESCRIPTION
Turns out that setting Time.timeScale to 0 pauses the Time.time field
as well, so there is no need to adjust any cooldown related
functionality.