### PR TITLE
Make boids ignore all other behaviors when in range of a scarecrow

### DIFF
--- a/Assets/Scripts/Boid/Scarecrow.cs
+++ b/Assets/Scripts/Boid/Scarecrow.cs
@@ -74,7 +74,7 @@ public class Scarecrow : Boid {
             hoverKp = 10f,
             targetHeight = 2f,
 
-            fearMultiplier = 10f,
+            fearMultiplier = 100f,
 
             colliderRadius = GetComponent<SphereCollider>().radius
         };


### PR DESCRIPTION
Disables all behaviors but "fear" when a boid is in range of an enemy scarecrow. Also fixes a bug: previously, the fear multiplier of the boid being scared was used instead of the fear multiplier of the scarecrow.