### PR TITLE
Fix scarecrow by disabling all behaviors but fear when a boid is in range

### DIFF
--- a/Assets/Scripts/Boid/Scarecrow.cs
+++ b/Assets/Scripts/Boid/Scarecrow.cs
@@ -74,7 +74,7 @@ public class Scarecrow : Boid {
             hoverKp = 10f,
             targetHeight = 2f,
 
-            fearMultiplier = 100f,
+            fearMultiplier = 1000f,
 
             colliderRadius = GetComponent<SphereCollider>().radius
         };


### PR DESCRIPTION
Also fixes a bug: previously, the fear multiplier of the boid being scared was used instead of the fear multiplier of the scarecrow